### PR TITLE
Add delete control with confirmation for application cards

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -24,6 +24,10 @@ const updateStatus = (id: string, newStatus: ApplicationStatus) => {
     setApplications(prev => prev.map(app => app.id === id ? {...app, status: newStatus, updated_at: new Date().toISOString()} : app));
 }
 
+const deleteApplication = (id: string) => {
+    setApplications((prev) => prev.filter((app) => app.id !== id));
+}
+
 
 const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -103,6 +107,7 @@ const statsArray = [
     <ApplicationList
       applications={applications}
       onStatusChange={updateStatus}
+      onDeleteApplication={deleteApplication}
     />
   
   </div>

--- a/components/application-card.tsx
+++ b/components/application-card.tsx
@@ -3,6 +3,7 @@ import { Application, ApplicationStatus } from "@/app/src/types";
 type ApplicationCardProps = {
   application: Application;
   onStatusChange: (id: string, newStatus: ApplicationStatus) => void;
+  onDelete: (id: string) => void;
 };
 
 const statusStyles: Record<ApplicationStatus, string> = {
@@ -21,9 +22,45 @@ function formatStatusLabel(status: ApplicationStatus) {
 export default function ApplicationCard({
   application,
   onStatusChange,
+  onDelete,
 }: ApplicationCardProps) {
+  const handleDelete = () => {
+    const shouldDelete = window.confirm(
+      `Delete ${application.position} at ${application.company}? This action cannot be undone.`
+    );
+
+    if (shouldDelete) {
+      onDelete(application.id);
+    }
+  };
+
   return (
-    <div className="rounded-[1.35rem] border border-white/6 bg-[#2f2d35] p-4 text-white shadow-[0_18px_40px_rgba(10,10,16,0.22)] ring-1 ring-black/10">
+    <div className="relative rounded-[1.35rem] border border-white/6 bg-[#2f2d35] p-4 text-white shadow-[0_18px_40px_rgba(10,10,16,0.22)] ring-1 ring-black/10">
+      <button
+        type="button"
+        onClick={handleDelete}
+        aria-label={`Delete ${application.company} application`}
+        className="absolute right-3 top-3 rounded-lg p-2 text-[#e6e2f0]/80 transition hover:bg-[#4d4a57] hover:text-[#ff8f9f] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#ff8f9f]"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M3 6h18" />
+          <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" />
+          <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
+          <path d="M10 11v6" />
+          <path d="M14 11v6" />
+        </svg>
+      </button>
       <div className="mb-4 flex items-start gap-3">
         <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-gradient-to-br from-[#8aa2ff] to-[#596dff] text-lg font-semibold text-white shadow-[0_10px_24px_rgba(89,109,255,0.35)]">
           {application.company.charAt(0).toUpperCase()}

--- a/components/application-list.tsx
+++ b/components/application-list.tsx
@@ -4,11 +4,13 @@ import ApplicationCard from "@/components/application-card";
 type ApplicationListProps = {
   applications: Application[];
   onStatusChange: (id: string, newStatus: ApplicationStatus) => void;
+  onDeleteApplication: (id: string) => void;
 };
 
 export default function ApplicationList({
   applications,
   onStatusChange,
+  onDeleteApplication,
 }: ApplicationListProps) {
   return (
     <section className="rounded-[1.75rem] border border-white/6 bg-[#26242c] p-4 shadow-[0_24px_60px_rgba(10,10,16,0.28)] ring-1 ring-black/10 md:p-6">
@@ -32,6 +34,7 @@ export default function ApplicationList({
             key={application.id}
             application={application}
             onStatusChange={onStatusChange}
+            onDelete={onDeleteApplication}
           />
         ))}
       </div>


### PR DESCRIPTION
### Motivation
- Provide a per-application delete action so users can remove individual job cards from the board with an explicit confirmation step.
- Use a trash icon positioned in the card header; `lucide-react` was attempted but unavailable in this environment, so an inline SVG trash icon is used as a fallback.

### Description
- Added `deleteApplication` state handler in `app/page.tsx` and passed it into `ApplicationList` via `onDeleteApplication`.
- Extended `ApplicationList` (`components/application-list.tsx`) props to accept `onDeleteApplication` and forwarded it to each `ApplicationCard` as `onDelete`.
- Updated `ApplicationCard` (`components/application-card.tsx`) to accept `onDelete`, render a top-right trash button (inline SVG), and prompt the user with `window.confirm` before calling `onDelete`.

### Testing
- Ran `npm run lint` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5e8e9a758832399606c6b31e9b956)